### PR TITLE
Prefill questionnaire based on user data

### DIFF
--- a/src/redux/dispatchers/user/requestUserData.js
+++ b/src/redux/dispatchers/user/requestUserData.js
@@ -62,7 +62,9 @@ async function fetchUserData(dispatch, keycloak) {
       )
     );
     dispatch(setAnswerActionCreator("province", data.personAddressProvince));
-    dispatch(setAnswerActionCreator("gender", data.personGender.toLowerCase()));
+    data.personGender === "SX1"
+      ? dispatch(setAnswerActionCreator("gender", "male"))
+      : dispatch(setAnswerActionCreator("gender", "female"));
   } else {
     return dispatch(
       networkRequestFailedActionCreator(

--- a/src/redux/dispatchers/user/requestUserData.js
+++ b/src/redux/dispatchers/user/requestUserData.js
@@ -6,6 +6,7 @@ import {
   networkRequestFailedActionCreator,
   NETWORK_REQUEST_TYPES,
   NETWORK_FAILED_REASONS,
+  setAnswerActionCreator,
 } from "../../actions";
 import { RESOURCE_TYPES } from "../resourceTypes";
 
@@ -53,13 +54,15 @@ async function fetchUserData(dispatch, keycloak) {
   }
 
   if (response.ok) {
-    return dispatch(
+    dispatch(
       networkReceivedActionCreator(
         RESOURCE_TYPES.USER_DATA,
         NETWORK_REQUEST_TYPES.GET,
         data
       )
     );
+    dispatch(setAnswerActionCreator("province", data.personAddressProvince));
+    dispatch(setAnswerActionCreator("gender", data.personGender.toLowerCase()));
   } else {
     return dispatch(
       networkRequestFailedActionCreator(

--- a/src/redux/dispatchers/user/requestUserData.test.js
+++ b/src/redux/dispatchers/user/requestUserData.test.js
@@ -44,7 +44,7 @@ describe("requestUserData", () => {
         personAddressLineItem1: "218 BIGGS ST",
         personEmailAddress: "Elizabeth.Andrew@fakemail.ca",
         personAddressCity: "Fredericton",
-        personGender: "Female",
+        personGender: "SX2",
         directDepositAccountNumber: 9999999,
         directDepositTransitNumber: 99999,
         personAddressPostalcode: "E3B6J6",
@@ -79,7 +79,7 @@ describe("requestUserData", () => {
           personAddressLineItem1: "218 BIGGS ST",
           personEmailAddress: "Elizabeth.Andrew@fakemail.ca",
           personAddressCity: "Fredericton",
-          personGender: "Female",
+          personGender: "SX2",
           directDepositAccountNumber: 9999999,
           directDepositTransitNumber: 99999,
           personAddressPostalcode: "E3B6J6",
@@ -93,7 +93,7 @@ describe("requestUserData", () => {
         }
       ),
       setAnswerActionCreator("province", "NB"),
-      setAnswerActionCreator("gender", "female"),
+      setAnswerActionCreator("gender", "sx2"),
     ];
 
     expect(store.getActions()).toEqual(expectedActions);

--- a/src/redux/dispatchers/user/requestUserData.test.js
+++ b/src/redux/dispatchers/user/requestUserData.test.js
@@ -93,7 +93,7 @@ describe("requestUserData", () => {
         }
       ),
       setAnswerActionCreator("province", "NB"),
-      setAnswerActionCreator("gender", "sx2"),
+      setAnswerActionCreator("gender", "female"),
     ];
 
     expect(store.getActions()).toEqual(expectedActions);

--- a/src/redux/dispatchers/user/requestUserData.test.js
+++ b/src/redux/dispatchers/user/requestUserData.test.js
@@ -7,6 +7,7 @@ import {
   networkRequestFailedActionCreator,
   networkReceivedActionCreator,
   networkRequestActionCreator,
+  setAnswerActionCreator,
 } from "../../actions";
 import { RESOURCE_TYPES } from "../resourceTypes";
 import thunk from "redux-thunk";
@@ -91,6 +92,8 @@ describe("requestUserData", () => {
           personFirstName: "Elizabeth",
         }
       ),
+      setAnswerActionCreator("province", "NB"),
+      setAnswerActionCreator("gender", "female"),
     ];
 
     expect(store.getActions()).toEqual(expectedActions);


### PR DESCRIPTION
# Description 📝

When user data is successfully received, use that data to prefill answers in the questionnaire.

## Taiga Link 🔗

[#471 User profile information is stored with answers in redux where applicable](https://taiga.dts-stn.com/project/ericdube-hfp-shared-backlog/task/471?kanban-status=130)

## Checklist ✅
- [ ] created story for all visual components
- [ ] created or modified necessary unit tests
- [ ] created or modified e2e tests
- [ ] modified README or any applicable documentation on the changes you made