### PR TITLE
Feature/488 Pass user data to Curam preintake endpoint on benefit Apply

### DIFF
--- a/src/pages/benefit.js
+++ b/src/pages/benefit.js
@@ -21,6 +21,7 @@ import { Spinner } from "../components/atoms/Spinner";
 
 //keycloak
 import { useKeycloak } from "@react-keycloak/web";
+import { userDataSelector } from "../redux/selectors";
 
 export function BenefitPage() {
   const [triedFetch, setTriedFetch] = useState(false);
@@ -45,6 +46,8 @@ export function BenefitPage() {
   const fetchBenefitsFailedObj = useSelector(
     (state) => state.benefits.benefitsData.fetchFailedObj
   );
+
+  const userProfileData = useSelector(userDataSelector);
 
   const answers = useSelector((state) => state.answers);
 
@@ -73,7 +76,8 @@ export function BenefitPage() {
           benefitData.benefitType,
           keycloak,
           keycloak.authenticated ? keycloak.idTokenParsed.guid : "",
-          answers
+          answers,
+          userProfileData
         )
       );
     }

--- a/src/redux/dispatchers/benefits/applyForBenefit.js
+++ b/src/redux/dispatchers/benefits/applyForBenefit.js
@@ -13,7 +13,8 @@ async function postApplyForBenefit(
   benefitType,
   keycloak,
   guid,
-  answers
+  answers,
+  userProfile
 ) {
   let response;
   try {
@@ -46,6 +47,27 @@ async function postApplyForBenefit(
           reasonForSeparation: answers["reasonForSeparation"],
           incomeDetails: answers["incomeDetails"],
           outOfWork: answers["outOfWork"],
+          person: {
+            sin: userProfile.personSin,
+            firstName: userProfile.personFirstName,
+            lastName: userProfile.personLastName,
+            dateOfBirth: userProfile.personDateOfBirth,
+            gender: userProfile.personGender,
+            emailAddress: userProfile.personEmailAddress,
+            phoneNumber: userProfile.personPhoneNumber,
+            address: {
+              lineItem1: userProfile.personAddressLineItem1,
+              lineItem2: userProfile.personAddressLineItem2,
+              city: userProfile.personAddressCity,
+              province: userProfile.personAddressProvince,
+              postalCode: userProfile.personAddressPostalCode,
+            },
+          },
+          bankingInfo: {
+            directDepositTransitNumber: userProfile.directDepositTransitNumber,
+            directDepositFiNumber: userProfile.directDepositFiNumber,
+            directDepositAccountNumber: userProfile.directDepositAccountNumber,
+          },
         }),
       }
     );
@@ -90,8 +112,22 @@ async function postApplyForBenefit(
  * @param keycloak
  * @param guid
  * @param answers
+ * @param userProfile
  */
-export function applyForBenefit(benefitType, keycloak, guid, answers) {
+export function applyForBenefit(
+  benefitType,
+  keycloak,
+  guid,
+  answers,
+  userProfile
+) {
   return (dispatch) =>
-    postApplyForBenefit(dispatch, benefitType, keycloak, guid, answers);
+    postApplyForBenefit(
+      dispatch,
+      benefitType,
+      keycloak,
+      guid,
+      answers,
+      userProfile
+    );
 }

--- a/src/redux/dispatchers/benefits/applyForBenefit.js
+++ b/src/redux/dispatchers/benefits/applyForBenefit.js
@@ -28,6 +28,27 @@ async function postApplyForBenefit(
           reasonForSeparation: answers["reasonForSeparation"],
           incomeDetails: answers["incomeDetails"],
           outOfWork: answers["outOfWork"],
+          person: {
+            sin: userProfile.personSin,
+            firstName: userProfile.personFirstName,
+            lastName: userProfile.personLastName,
+            dateOfBirth: userProfile.personDateOfBirth,
+            gender: userProfile.personGender,
+            emailAddress: userProfile.personEmailAddress,
+            phoneNumber: userProfile.personPhoneNumber,
+            address: {
+              lineItem1: userProfile.personAddressLineItem1,
+              lineItem2: userProfile.personAddressLineItem2,
+              city: userProfile.personAddressCity,
+              province: userProfile.personAddressProvince,
+              postalCode: userProfile.personAddressPostalcode,
+            },
+          },
+          bankingInfo: {
+            directDepositTransitNumber: userProfile.directDepositTransitNumber,
+            directDepositFiNumber: userProfile.directDepositFiNumber,
+            directDepositAccountNumber: userProfile.directDepositAccountNumber,
+          },
         }
       )
     );
@@ -60,7 +81,7 @@ async function postApplyForBenefit(
               lineItem2: userProfile.personAddressLineItem2,
               city: userProfile.personAddressCity,
               province: userProfile.personAddressProvince,
-              postalCode: userProfile.personAddressPostalCode,
+              postalCode: userProfile.personAddressPostalcode,
             },
           },
           bankingInfo: {

--- a/src/redux/dispatchers/benefits/applyForBenefit.test.js
+++ b/src/redux/dispatchers/benefits/applyForBenefit.test.js
@@ -46,7 +46,25 @@ describe("applyForBenefit", () => {
         "HFP111",
         mockKeycloakFunc,
         "cc6e16b0-db92-459a-91df-f8144befdda9",
-        {}
+        {},
+        {
+          guid: "31360512-2d79-4baa-8696-b612de6cbff5",
+          personAddressLineItem2: "NULL",
+          personPhoneNumber: 4259012345,
+          personAddressLineItem1: "218 BIGGS ST",
+          personEmailAddress: "Elizabeth.Andrew@fakemail.ca",
+          personAddressCity: "Fredericton",
+          personGender: "SX2",
+          directDepositAccountNumber: 9999999,
+          directDepositTransitNumber: 99999,
+          personAddressPostalcode: "E3B6J6",
+          personAddressProvince: "NB",
+          personDateOfBirth: "06/12/1976",
+          directDepositFiNumber: 999,
+          personSin: 802435215,
+          personLastName: "Andrew",
+          personFirstName: "Elizabeth",
+        }
       )
     );
 
@@ -57,6 +75,27 @@ describe("applyForBenefit", () => {
         undefined,
         {
           benefitType: "HFP111",
+          person: {
+            sin: 802435215,
+            firstName: "Elizabeth",
+            lastName: "Andrew",
+            dateOfBirth: "06/12/1976",
+            gender: "SX2",
+            emailAddress: "Elizabeth.Andrew@fakemail.ca",
+            phoneNumber: 4259012345,
+            address: {
+              lineItem1: "218 BIGGS ST",
+              lineItem2: "NULL",
+              city: "Fredericton",
+              province: "NB",
+              postalCode: "E3B6J6",
+            },
+          },
+          bankingInfo: {
+            directDepositTransitNumber: 99999,
+            directDepositFiNumber: 999,
+            directDepositAccountNumber: 9999999,
+          },
         }
       ),
     ]);
@@ -74,7 +113,25 @@ describe("applyForBenefit", () => {
         "HFP111",
         mockKeycloakFunc,
         "cc6e16b0-db92-459a-91df-f8144befdda9",
-        {}
+        {},
+        {
+          guid: "31360512-2d79-4baa-8696-b612de6cbff5",
+          personAddressLineItem2: "NULL",
+          personPhoneNumber: 4259012345,
+          personAddressLineItem1: "218 BIGGS ST",
+          personEmailAddress: "Elizabeth.Andrew@fakemail.ca",
+          personAddressCity: "Fredericton",
+          personGender: "SX2",
+          directDepositAccountNumber: 9999999,
+          directDepositTransitNumber: 99999,
+          personAddressPostalcode: "E3B6J6",
+          personAddressProvince: "NB",
+          personDateOfBirth: "06/12/1976",
+          directDepositFiNumber: 999,
+          personSin: 802435215,
+          personLastName: "Andrew",
+          personFirstName: "Elizabeth",
+        }
       )
     );
 
@@ -85,6 +142,27 @@ describe("applyForBenefit", () => {
         undefined,
         {
           benefitType: "HFP111",
+          person: {
+            sin: 802435215,
+            firstName: "Elizabeth",
+            lastName: "Andrew",
+            dateOfBirth: "06/12/1976",
+            gender: "SX2",
+            emailAddress: "Elizabeth.Andrew@fakemail.ca",
+            phoneNumber: 4259012345,
+            address: {
+              lineItem1: "218 BIGGS ST",
+              lineItem2: "NULL",
+              city: "Fredericton",
+              province: "NB",
+              postalCode: "E3B6J6",
+            },
+          },
+          bankingInfo: {
+            directDepositTransitNumber: 99999,
+            directDepositFiNumber: 999,
+            directDepositAccountNumber: 9999999,
+          },
         }
       ),
       networkRequestFailedActionCreator(
@@ -114,7 +192,25 @@ describe("applyForBenefit", () => {
         "HFP111",
         mockKeycloakFunc,
         "cc6e16b0-db92-459a-91df-f8144befdda9",
-        {}
+        {},
+        {
+          guid: "31360512-2d79-4baa-8696-b612de6cbff5",
+          personAddressLineItem2: "NULL",
+          personPhoneNumber: 4259012345,
+          personAddressLineItem1: "218 BIGGS ST",
+          personEmailAddress: "Elizabeth.Andrew@fakemail.ca",
+          personAddressCity: "Fredericton",
+          personGender: "SX2",
+          directDepositAccountNumber: 9999999,
+          directDepositTransitNumber: 99999,
+          personAddressPostalcode: "E3B6J6",
+          personAddressProvince: "NB",
+          personDateOfBirth: "06/12/1976",
+          directDepositFiNumber: 999,
+          personSin: 802435215,
+          personLastName: "Andrew",
+          personFirstName: "Elizabeth",
+        }
       )
     );
 
@@ -125,6 +221,27 @@ describe("applyForBenefit", () => {
         undefined,
         {
           benefitType: "HFP111",
+          person: {
+            sin: 802435215,
+            firstName: "Elizabeth",
+            lastName: "Andrew",
+            dateOfBirth: "06/12/1976",
+            gender: "SX2",
+            emailAddress: "Elizabeth.Andrew@fakemail.ca",
+            phoneNumber: 4259012345,
+            address: {
+              lineItem1: "218 BIGGS ST",
+              lineItem2: "NULL",
+              city: "Fredericton",
+              province: "NB",
+              postalCode: "E3B6J6",
+            },
+          },
+          bankingInfo: {
+            directDepositTransitNumber: 99999,
+            directDepositFiNumber: 999,
+            directDepositAccountNumber: 9999999,
+          },
         }
       ),
       networkRequestFailedActionCreator(


### PR DESCRIPTION
# Description 📝

User data is passed into the request sent out to the Curam preintake API endpoint when a user is viewing a Benefit More Info page and selects "Apply". Currently because of security certificate issues on Curam's end you will have to start Chrome with web security disabled and ignoring invalid security certs to have the application properly redirect to Curam.

## Taiga Link 🔗

[Add user profile data to Curam preintake request](https://taiga.dts-stn.com/project/ericdube-hfp-shared-backlog/task/488?kanban-status=130)

## Checklist ✅
- [ ] created story for all visual components
- [x] created or modified necessary unit tests
- [ ] created or modified e2e tests
- [ ] modified README or any applicable documentation on the changes you made