### PR TITLE
only show questions when authenticated and questions are available

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -43,7 +43,6 @@ export function Home() {
   const [triedFetchedBenefits, setTriedFetchedBenefits] = useState(false);
   const [triedFetchedQuestions, setTriedFetchedQuestions] = useState(false);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [displayQuestions, setDisplayQuestions] = useState(false);
   const [previouBtnDisabled, setPreviousBtnDisabled] = useState(true);
   const [nextBtnDisabled, setNextBtnDisabled] = useState(true);
   const [nextButtonText, setNextButtonText] = useState("Next Question");
@@ -158,7 +157,6 @@ export function Home() {
     if (!keycloak.authenticated) {
       keycloak.login();
     }
-    setDisplayQuestions(true);
   };
 
   const seeMyCasesButtonClickHandler = () => {
@@ -256,7 +254,7 @@ export function Home() {
         {/* Display the questions or button  */}
 
         <section>
-          {displayQuestions ? (
+          {keycloak.authenticated && questions[currentQuestionIndex] ? (
             <Questions
               id={questions[currentQuestionIndex].questionId}
               required={true}


### PR DESCRIPTION
# Description 📝

Issue: When an unauthenticated user selects "Match Me To Benefits", the questions would appear momentarily before the user was redirected to login, once logged in the user would be redirected back to the SPF and have to click "Match Me To Benefits" again to get the questions to appear.

Fix: Use keycloak.authenticated and questionDataSelector as conditions for displaying the questions. User should never see the questions until fully authenticated and the questions are populated in application state.

## Taiga Link 🔗

[ your tiaga issue link here ]

## Checklist ✅
- [ ] created story for all visual components
- [ ] created or modified necessary unit tests
- [ ] created or modified e2e tests
- [ ] modified README or any applicable documentation on the changes you made