### PR TITLE
add alert if not answered and disable next button

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -44,7 +44,7 @@ export function Home() {
   const [triedFetchedQuestions, setTriedFetchedQuestions] = useState(false);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [previouBtnDisabled, setPreviousBtnDisabled] = useState(true);
-  const [nextBtnDisabled, setNextBtnDisabled] = useState(true);
+  const [nextBtnDisabled, setNextBtnDisabled] = useState(false);
   const [nextButtonText, setNextButtonText] = useState("Next Question");
   const [triedFetchElegibility, setTriedFetchElegibility] = useState(false);
 
@@ -186,20 +186,27 @@ export function Home() {
   };
 
   const nextCurrentQuestion = () => {
-    if (currentQuestionIndex === questions.length - 2) {
-      setNextButtonText("Submit");
-    }
-    if (currentQuestionIndex < questions.length - 1) {
-      setCurrentQuestionIndex(currentQuestionIndex + 1);
-    } else {
+    const currentQuestion = questions[currentQuestionIndex];
+    const answerForQuestion = answers[currentQuestion.questionId];
+    if (!answerForQuestion) {
       setNextBtnDisabled(true);
-    }
+      alert("Answer required for question");
+    } else {
+      if (currentQuestionIndex === questions.length - 2) {
+        setNextButtonText("Submit");
+      }
+      if (currentQuestionIndex < questions.length - 1) {
+        setCurrentQuestionIndex(currentQuestionIndex + 1);
+      } else {
+        setNextBtnDisabled(true);
+      }
 
-    if (previouBtnDisabled) {
-      setPreviousBtnDisabled(false);
-    } else if (currentQuestionIndex === questions.length - 1) {
-      dispatch(requestEligibility(answers));
-      setTriedFetchElegibility(true);
+      if (previouBtnDisabled) {
+        setPreviousBtnDisabled(false);
+      } else if (currentQuestionIndex === questions.length - 1) {
+        dispatch(requestEligibility(answers));
+        setTriedFetchElegibility(true);
+      }
     }
   };
 


### PR DESCRIPTION
# Description 📝

Simple fix where the next button was disabled by default for the questionnaire. Even if there was a value from the user service the user would not be allowed to proceed due to the button being disabled.

Changed so that the next button is enabled by default and if there is no value an alert will show saying the question needs to be answered. The button will be disabled following that. If there is a value, it proceeds as normal 

## Checklist ✅
- [ ] created story for all visual components
- [ ] created or modified necessary unit tests
- [ ] created or modified e2e tests
- [ ] modified README or any applicable documentation on the changes you made