### PR TITLE
Adding the curam domain to the ingress host rules

### DIFF
--- a/helmfile/overrides/servicecanadaprototypefrontend.yaml.gotmpl
+++ b/helmfile/overrides/servicecanadaprototypefrontend.yaml.gotmpl
@@ -18,6 +18,7 @@ ingress:
       {{ else }}
           - servicecanadaprototypefrontend-{{ .Environment.Name }}.{{ requiredEnv "BASE_DOMAIN_DEV" }}
           - servicecanadaprototypefrontend-{{ requiredEnv "BASE_DOMAIN_DEV" }}
+          - servicecanadaprototypefrontend-{{ .Environment.Name }}.dtbdmhfp.com
       {{ end }} 
       annotations: {}
       # kubernetes.io/ingress.class: traefik


### PR DESCRIPTION
# Description 📝

Adding the new curam DNS name to the ingress host rules so that the app is reachable under the Curam DNS.
