### PR TITLE
Story #305 - Carry over unauthenticated pre-screening responses into the authenticated application intake

### DIFF
--- a/src/components/organisms/Page.js
+++ b/src/components/organisms/Page.js
@@ -38,7 +38,7 @@ export function Page(props) {
   useEffect(() => {
     if (keycloak.authenticated && Object.keys(userProfileData).length === 0) {
       let localAnswers = loadAnswers();
-      if (localAnswers && Object.keys(localAnswers).length) {
+      if (localAnswers && Object.keys(localAnswers).length > 0) {
         dispatch(setAllAnswersActionCreator(localAnswers));
         clearAnswers();
       } else {

--- a/src/components/organisms/Page.js
+++ b/src/components/organisms/Page.js
@@ -9,6 +9,8 @@ import { useKeycloak } from "@react-keycloak/web";
 import { changeLanguageCreator, LANGUAGES } from "../../redux/actions";
 import { getUserData } from "../../redux/dispatchers/user/requestUserData";
 import { getClientDash } from "../../redux/dispatchers/benefits";
+import { loadAnswers, saveAnswers, clearAnswers } from "../../localStorage";
+import { setAllAnswersActionCreator } from "../../redux/actions/answers";
 
 //react router
 import { useHistory } from "react-router-dom";
@@ -23,6 +25,7 @@ export function Page(props) {
   const { t } = useTranslation();
   const userProfileData = useSelector(userDataSelector);
   const history = useHistory();
+  const answers = useSelector((state) => state.answers);
 
   let languageButtonHandler = () => {
     if (language === "en") {
@@ -34,7 +37,13 @@ export function Page(props) {
 
   useEffect(() => {
     if (keycloak.authenticated && Object.keys(userProfileData).length === 0) {
-      dispatch(getUserData(keycloak));
+      let localAnswers = loadAnswers();
+      if (localAnswers && Object.keys(localAnswers).length) {
+        dispatch(setAllAnswersActionCreator(localAnswers));
+        clearAnswers();
+      } else {
+        dispatch(getUserData(keycloak));
+      }
     }
   }, [keycloak, dispatch, userProfileData]);
 
@@ -58,6 +67,7 @@ export function Page(props) {
         logoutText={t("logout")}
         isAuthenticated={keycloak.authenticated}
         onLogin={() => {
+          saveAnswers(answers);
           keycloak.login();
         }}
         userName={`${

--- a/src/components/organisms/Page.js
+++ b/src/components/organisms/Page.js
@@ -36,7 +36,11 @@ export function Page(props) {
   };
 
   useEffect(() => {
-    if (keycloak.authenticated && Object.keys(userProfileData).length === 0) {
+    if (
+      keycloak.authenticated &&
+      Object.keys(userProfileData).length === 0 &&
+      Object.keys(answers).length === 0
+    ) {
       let localAnswers = loadAnswers();
       if (localAnswers && Object.keys(localAnswers).length > 0) {
         dispatch(setAllAnswersActionCreator(localAnswers));
@@ -45,7 +49,7 @@ export function Page(props) {
         dispatch(getUserData(keycloak));
       }
     }
-  }, [keycloak, dispatch, userProfileData]);
+  }, [keycloak, dispatch, userProfileData, answers]);
 
   let userNameClickHandler = () => {
     dispatch(

--- a/src/components/organisms/Page.js
+++ b/src/components/organisms/Page.js
@@ -70,7 +70,8 @@ export function Page(props) {
 
   useEffect(() => {
     if (
-      Object.keys(userProfileData).length !== 0 &&
+      triedFetchUserData &&
+      !fetchUserDataFailed &&
       triedAnswersFromLocalStorageFailed
     ) {
       dispatch(
@@ -83,7 +84,13 @@ export function Page(props) {
         ? dispatch(setAnswerActionCreator("gender", "male"))
         : dispatch(setAnswerActionCreator("gender", "female"));
     }
-  }, [userProfileData, dispatch, triedAnswersFromLocalStorageFailed]);
+  }, [
+    userProfileData,
+    dispatch,
+    triedFetchUserData,
+    fetchUserDataFailed,
+    triedAnswersFromLocalStorageFailed,
+  ]);
 
   useEffect(() => {
     let localAnswers = loadAnswers();

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -1,0 +1,24 @@
+export const loadAnswers = () => {
+  try {
+    const serializedAnswers = localStorage.getItem("answers");
+    if (serializedAnswers === null) {
+      return undefined;
+    }
+    return JSON.parse(serializedAnswers);
+  } catch (err) {
+    return undefined;
+  }
+};
+
+export const saveAnswers = (answers) => {
+  try {
+    const serializedAnswers = JSON.stringify(answers);
+    localStorage.setItem("answers", serializedAnswers);
+  } catch (err) {
+    //TODO: Log
+  }
+};
+
+export const clearAnswers = () => {
+  localStorage.removeItem("answers");
+};

--- a/src/pages/benefit.js
+++ b/src/pages/benefit.js
@@ -22,6 +22,7 @@ import { Spinner } from "../components/atoms/Spinner";
 //keycloak
 import { useKeycloak } from "@react-keycloak/web";
 import { userDataSelector } from "../redux/selectors";
+import { saveAnswers } from "../localStorage";
 
 export function BenefitPage() {
   const [triedFetch, setTriedFetch] = useState(false);
@@ -69,6 +70,7 @@ export function BenefitPage() {
   const applyButtonClickHandler = () => {
     // if not logged in log in first
     if (!keycloak.authenticated) {
+      saveAnswers(answers);
       keycloak.login();
     } else if (benefitData.benefitTag.includes("External")) {
       window.open("https://".concat(benefitData.redirectUrl), "_blank");

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -188,7 +188,6 @@ export function Home() {
         Prov. Rate = , ${entitlement["provincialRate"]},
         Grant = , ${entitlement["entitlementGrant"]}`;
       setEntitlementData(entitlementData);
-      console.log(entitlementData);
     }
   };
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -52,6 +52,7 @@ export function Home() {
   const [triedFetchElegibility, setTriedFetchElegibility] = useState(false);
   const [triedFetchedEntitlement, setTriedFetchedEntitlement] = useState(false);
   const [entitlementData, setEntitlementData] = useState("");
+  const [displayQuestions, setDisplayQuestions] = useState(false);
 
   const { keycloak } = useKeycloak();
 
@@ -203,10 +204,7 @@ export function Home() {
   };
 
   const matchMeToBenefitsButtonClickHandler = () => {
-    // if not logged in log in first
-    if (!keycloak.authenticated) {
-      keycloak.login();
-    }
+    setDisplayQuestions(true);
   };
 
   const seeMyCasesButtonClickHandler = () => {
@@ -311,7 +309,7 @@ export function Home() {
         {/* Display the questions or button  */}
 
         <section>
-          {keycloak.authenticated && questions[currentQuestionIndex] ? (
+          {displayQuestions ? (
             <Questions
               id={questions[currentQuestionIndex].questionId}
               required={true}

--- a/src/redux/actions/actionTypes.js
+++ b/src/redux/actions/actionTypes.js
@@ -13,6 +13,7 @@ export const ACTION_TYPES = {
 
   SET_ANSWER: "SET_ANSWER",
   REMOVE_ANSWER: "REMOVE_ANSWER",
+  SET_ALL_ANSWERS: "SET_ALL_ANSWERS",
 };
 
 // network action constants

--- a/src/redux/actions/answers/index.js
+++ b/src/redux/actions/answers/index.js
@@ -1,2 +1,3 @@
 export { setAnswerActionCreator } from "./setAnswerAction";
 export { removeAnswerActionCreator } from "./removeAnswerAction";
+export { setAllAnswersActionCreator } from "./setAllAnswersAction";

--- a/src/redux/actions/answers/setAllAnswersAction.js
+++ b/src/redux/actions/answers/setAllAnswersAction.js
@@ -1,0 +1,8 @@
+import { ACTION_TYPES } from "../actionTypes";
+
+export function setAllAnswersActionCreator(answers) {
+  return {
+    type: ACTION_TYPES.SET_ALL_ANSWERS,
+    answers,
+  };
+}

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -15,6 +15,10 @@ export {
 } from "./benefits";
 
 //answer actions
-export { removeAnswerActionCreator, setAnswerActionCreator } from "./answers";
+export {
+  removeAnswerActionCreator,
+  setAnswerActionCreator,
+  setAllAnswersActionCreator,
+} from "./answers";
 
 export * from "./actionTypes";

--- a/src/redux/dispatchers/user/requestUserData.js
+++ b/src/redux/dispatchers/user/requestUserData.js
@@ -6,7 +6,6 @@ import {
   networkRequestFailedActionCreator,
   NETWORK_REQUEST_TYPES,
   NETWORK_FAILED_REASONS,
-  setAnswerActionCreator,
 } from "../../actions";
 import { RESOURCE_TYPES } from "../resourceTypes";
 
@@ -54,17 +53,13 @@ async function fetchUserData(dispatch, keycloak) {
   }
 
   if (response.ok) {
-    dispatch(
+    return dispatch(
       networkReceivedActionCreator(
         RESOURCE_TYPES.USER_DATA,
         NETWORK_REQUEST_TYPES.GET,
         data
       )
     );
-    dispatch(setAnswerActionCreator("province", data.personAddressProvince));
-    data.personGender === "SX1"
-      ? dispatch(setAnswerActionCreator("gender", "male"))
-      : dispatch(setAnswerActionCreator("gender", "female"));
   } else {
     return dispatch(
       networkRequestFailedActionCreator(
@@ -79,7 +74,7 @@ async function fetchUserData(dispatch, keycloak) {
 }
 
 /**
- * dispatch function which gets a list of benefits from the strapi api.
+ * dispatch function which gets user profile data from the user service.
  * see strapi documentation on parameters
  * https://strapi.io/documentation/v3.x/content-api/parameters.html
  * @param start - the start index

--- a/src/redux/dispatchers/user/requestUserData.test.js
+++ b/src/redux/dispatchers/user/requestUserData.test.js
@@ -92,8 +92,6 @@ describe("requestUserData", () => {
           personFirstName: "Elizabeth",
         }
       ),
-      setAnswerActionCreator("province", "NB"),
-      setAnswerActionCreator("gender", "female"),
     ];
 
     expect(store.getActions()).toEqual(expectedActions);

--- a/src/redux/reducers/answers/answersReducer.js
+++ b/src/redux/reducers/answers/answersReducer.js
@@ -15,5 +15,10 @@ export const answers = function (state = {}, action) {
       return data;
     default:
       return state;
+    case ACTION_TYPES.SET_ALL_ANSWERS:
+      return {
+        ...state,
+        ...action.answers,
+      };
   }
 };


### PR DESCRIPTION
# Description 📝

If a user is unauthenticated, question answers from the current session are saved when selecting "Apply" in the Benefits Details Page or "Login" from any page. User is then routed to the login and if successful are redirected back to the Benefit Details Page at which point local storage is checked for the answers data and if it is there, it is restored to the application state. User can then apply using those answers.

If a user has not submitted answers to the questionnaire and selects "Apply" on the Benefit Details Page, they will be taken to the login and if successful, are returned to the Benefit Details Page and their user profile data will be used to to pre-fill answers where possible.

Answers stored in local storage are cleared on logout.

## Taiga Link 🔗

[Remove forced authentication from Match me to benefits button](https://taiga.dts-stn.com/project/ericdube-hfp-shared-backlog/task/513?kanban-status=130)

[Store unauthenticated answers in local storage](https://taiga.dts-stn.com/project/ericdube-hfp-shared-backlog/task/516?kanban-status=132)

[Only authenticate users on "Apply Now"](https://taiga.dts-stn.com/project/ericdube-hfp-shared-backlog/task/517?kanban-status=130)

## Checklist ✅
- [ ] created story for all visual components
- [ ] created or modified necessary unit tests
- [ ] created or modified e2e tests
- [ ] modified README or any applicable documentation on the changes you made